### PR TITLE
Enforce separate auth validity window for solo operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Usage of ./rescue-proxy:
         Address on which to reply to admin/metrics requests (default "0.0.0.0:8000")
   -api-addr string
         Address on which to reply to gRPC API requests (default "0.0.0.0:8080")
-  -auth-valid-for string
-        The duration after which a credential should be considered invalid, eg, 360h for 15 days (default "360h")
   -bn-url string
         URL to the beacon node to proxy, eg, http://localhost:5052
   -cache-path string

--- a/config.go
+++ b/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"time"
 )
 
 type Config struct {
@@ -20,7 +19,6 @@ type Config struct {
 	GRPCTLSKeyFile       string
 	RocketStorageAddr    string
 	CredentialSecret     string
-	AuthValidityWindow   time.Duration
 	CachePath            string
 	EnableSoloValidators bool
 	Debug                bool
@@ -42,7 +40,6 @@ func initFlags() *Config {
 	rocketStorageAddrFlag := flag.String("rocketstorage-addr", "0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46", "Address of the Rocket Storage contract. Defaults to mainnet")
 	debug := flag.Bool("debug", false, "Whether to enable verbose logging")
 	credentialSecretFlag := flag.String("hmac-secret", "test-secret", "The secret to use for HMAC")
-	authValidityWindowFlag := flag.String("auth-valid-for", "360h", "The duration after which a credential should be considered invalid, eg, 360h for 15 days")
 	cachePathFlag := flag.String("cache-path", "", "A path to cache EL data in. Leave blank to disable caching.")
 	enableSoloValidatorsFlag := flag.Bool("enable-solo-validators", true, "Whether or not to allow solo validators access.")
 	forceBNJSONFlag := flag.Bool("force-bn-json", false, "Disables SSZ in the BN.")
@@ -112,19 +109,6 @@ func initFlags() *Config {
 
 	if *credentialSecretFlag == "" {
 		fmt.Fprintf(os.Stderr, "Invalid -hmac-secret:\n")
-		os.Exit(1)
-		return nil
-	}
-
-	if *authValidityWindowFlag == "" {
-		fmt.Fprintf(os.Stderr, "Invalid -auth-valid-for:\n")
-		os.Exit(1)
-		return nil
-	}
-
-	config.AuthValidityWindow, err = time.ParseDuration(*authValidityWindowFlag)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Invalid -auth-valid-for:\n%v\n", err)
 		os.Exit(1)
 		return nil
 	}

--- a/router/authentication_test.go
+++ b/router/authentication_test.go
@@ -22,7 +22,7 @@ func setupAuthTest(t *testing.T) *auth {
 	t.Cleanup(metrics.Deinit)
 
 	cm := credentials.NewCredentialManager(sha256.New, []byte("test"))
-	a := initAuth(cm, time.Minute*5)
+	a := initAuth(cm)
 	return a
 }
 
@@ -53,7 +53,7 @@ func TestExpiredCredential(t *testing.T) {
 	a := setupAuthTest(t)
 
 	// Create a valid credential
-	cred, err := a.cm.Create(time.Now().Add(-time.Hour), nodeId, pb.OperatorType_OT_ROCKETPOOL)
+	cred, err := a.cm.Create(time.Now().Add(-(time.Hour * 24 * 30)), nodeId, pb.OperatorType_OT_ROCKETPOOL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +183,7 @@ func TestErrorMessages(t *testing.T) {
 	a := setupAuthTest(t)
 
 	// Create an expired credential
-	cred, err := a.cm.Create(time.Now().Add(-time.Hour), nodeId, pb.OperatorType_OT_ROCKETPOOL)
+	cred, err := a.cm.Create(time.Now().Add(-(time.Hour * 24 * 30)), nodeId, pb.OperatorType_OT_ROCKETPOOL)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/router/router.go
+++ b/router/router.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/Rocket-Pool-Rescue-Node/credentials"
 	"github.com/Rocket-Pool-Rescue-Node/credentials/pb"
@@ -34,7 +33,6 @@ type ProxyRouter struct {
 	EL                   executionlayer.ExecutionLayer
 	CL                   consensuslayer.ConsensusLayer
 	CredentialSecret     string
-	AuthValidityWindow   time.Duration
 	EnableSoloValidators bool
 
 	gbp  *gbp.GuardedBeaconProxy
@@ -355,7 +353,6 @@ func (pr *ProxyRouter) Init() {
 			sha256.New,
 			[]byte(pr.CredentialSecret),
 		),
-		pr.AuthValidityWindow,
 	)
 
 	// Create the reverse proxy.

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -81,7 +81,6 @@ func setup(t *testing.T, errs chan error) routerTest {
 		EL:                   el,
 		Logger:               zaptest.NewLogger(t),
 		CredentialSecret:     "test",
-		AuthValidityWindow:   time.Hour,
 		EnableSoloValidators: true,
 	}
 	pr.Init()

--- a/service.go
+++ b/service.go
@@ -134,7 +134,6 @@ func (s *Service) run(ctx context.Context, errs chan error) {
 		Logger:               s.Logger,
 		EL:                   s.el,
 		CL:                   s.cl,
-		AuthValidityWindow:   s.Config.AuthValidityWindow,
 		EnableSoloValidators: s.Config.EnableSoloValidators,
 		CredentialSecret:     s.Config.CredentialSecret,
 	}


### PR DESCRIPTION
Don't see a reason to make these hyper-tunable in the end. May as well use constants.