### PR TITLE
Typo Update consensus-layer.go

### DIFF
--- a/consensuslayer/consensus-layer.go
+++ b/consensuslayer/consensus-layer.go
@@ -113,7 +113,7 @@ func (c *CachingConsensusLayer) Init(ctx context.Context) error {
 	// Listen for head updates
 	err = c.client.Events(ctx, []string{"head"}, c.onHeadUpdate)
 	if err != nil {
-		c.logger.Warn("Clouldn't subscribe to CL events. Metrics will be inaccurate", zap.Error(err))
+		c.logger.Warn("Couldn't subscribe to CL events. Metrics will be inaccurate", zap.Error(err))
 	}
 
 	validatorCacheConfig := bigcache.DefaultConfig(10 * time.Hour)


### PR DESCRIPTION
### Description:
This pull request fixes a minor typographical error found in the `onHeadUpdate` method. The word **"Clouldn't"** was incorrectly used in the log message instead of **"Couldn't."**

### Issue:
In the `onHeadUpdate` method, the following line contains a misspelling:

```go
c.logger.Warn("Clouldn't subscribe to CL events. Metrics will be inaccurate", zap.Error(err))
```

### Typo:
The word **"Clouldn't"** was a misspelling of **"Couldn't."**

### Corrected:
```go
c.logger.Warn("Couldn't subscribe to CL events. Metrics will be inaccurate", zap.Error(err))
```

### Importance:
While this is a minor typo, correcting it ensures better clarity and professionalism in the codebase. Accurate log messages are crucial for developers debugging and maintaining the application. A misspelled word in log output can cause confusion or make it more difficult to quickly identify issues. It's a good practice to maintain proper spelling and consistency throughout the code, especially in logs that are used for troubleshooting.
